### PR TITLE
fix deprecated bpf maps, deprecated apis, and some build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
 )
+target_compile_definitions(probes PUBLIC __TARGET_ARCH_x86)
 
 target_compile_options(
     probes
@@ -75,6 +76,7 @@ target_compile_options(
 )
 
 target_compile_definitions(libebpfsnitchd PUBLIC SPDLOG_FMT_EXTERNAL)
+target_compile_definitions(libebpfsnitchd PUBLIC __TARGET_ARCH_x86)
 
 target_include_directories(
     libebpfsnitchd

--- a/bpf_wrapper.cpp
+++ b/bpf_wrapper.cpp
@@ -176,10 +176,6 @@ bpf_wrapper_object::impl::~impl()
             m_log->error("bpf_link__destroy() failed");
         }
     }
-
-    if (bpf_object__unload(m_object.get()) != 0) {
-        m_log->error("bpf_object__unload() failed");
-    }
 }
 
 void

--- a/probes.c
+++ b/probes.c
@@ -24,38 +24,45 @@ struct ebpf_event_t {
     uint8_t     m_protocol;
 } __attribute__((packed));
 
-struct bpf_map_def SEC("maps") g_probe_ipv4_events = {
-    .type        = BPF_MAP_TYPE_RINGBUF,
-    .max_entries = 4096 * 64
-};
 
-struct bpf_map_def SEC("maps") g_ipv4_tcp_connect_map = {
-    .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(uint64_t),
-    .value_size  = sizeof(struct sock *),
-    .max_entries = 1000
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096 * 64);
+} g_probe_ipv4_events SEC(".maps");
 
-struct bpf_map_def SEC("maps") g_ipv6_tcp_connect_map = {
-    .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(uint64_t),
-    .value_size  = sizeof(struct sock *),
-    .max_entries = 1000
-};
 
-struct bpf_map_def SEC("maps") g_send_map1 = {
-    .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(uint64_t),
-    .value_size  = sizeof(struct socket *),
-    .max_entries = 1000
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1000);
+    __type(key, uint64_t);
+    __type(value, struct sock *);
+} g_ipv4_tcp_connect_map SEC(".maps");
 
-struct bpf_map_def SEC("maps") g_send_map2 = {
-    .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(uint64_t),
-    .value_size  = sizeof(struct msghdr *),
-    .max_entries = 1000
-};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1000);
+    __type(key, uint64_t);
+    __type(value, struct sock *);
+} g_ipv6_tcp_connect_map SEC(".maps");
+
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1000);
+    __type(key, uint64_t);
+    __type(value, struct socket *);
+} g_send_map1 SEC(".maps");
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1000);
+    __type(key, uint64_t);
+    __type(value, struct msghdr *);
+} g_send_map2 SEC(".maps");
+
 
 #define AF_INET 2
 


### PR DESCRIPTION
Build against libbpf v1. Two changes needed: 

1. The BPF map definitions, as used, are deprecated. Replaced with BTF-defined map definitions.
See here: https://github.com/libbpf/libbpf/issues/272

2. bpf_object__unload api call deprecated. unload and free takes place in bpf_object__close
See here: https://github.com/libbpf/libbpf/issues/290

Also needed the target arch defined in makefile to build on my system (an arch derived distro).

BTW thanks nice project.